### PR TITLE
Handle null user.tags gracefully in app/[username]/page.js

### DIFF
--- a/src/app/[username]/page.js
+++ b/src/app/[username]/page.js
@@ -135,7 +135,7 @@ export default async function Page({ params }) {
               <div className="p-6">{user.bio}</div>
 
               <ul className="flex flex-row gap-2 justify-center pb-2">
-                {user.tags.split(",").map((tag) => (
+                {user.tags && user.tags.split(",").map((tag) => (
                   <li key={tag}>
                     <Badge text={tag} />
                   </li>


### PR DESCRIPTION
**PR Description:**

### What does this PR do?
This PR addresses an issue where attempting to map over `user.tags` after splitting it would result in an error when `user.tags` is null in the response.

### Changes Made:
- Added a conditional check to ensure `user.tags` is not null before mapping over it in `app/[username]/page.js`.

### Why is this change needed?
In certain cases, the `user.tags` field in the response may be null, which was causing a runtime error when attempting to split and map over it. This change ensures that we handle this scenario gracefully by checking if `user.tags` exists and is not null before proceeding with the mapping operation.

### How was this tested?
- Tested locally with various scenarios including null `user.tags` in the response.
- Verified that the UI renders correctly without errors when `user.tags` is null.


### Screenshot of error :
![Screenshot from 2024-07-03 11-01-03](https://github.com/EddieHubCommunity/CreatorsRegistry/assets/58268246/d1cf9a86-faff-4d1d-823d-e4b571fe75fa)



This PR ensures robustness and improves error handling in scenarios where `user.tags` may be null, enhancing the reliability and stability of the application.
